### PR TITLE
Update Dependencies

### DIFF
--- a/calendar/build.gradle.kts
+++ b/calendar/build.gradle.kts
@@ -1,0 +1,63 @@
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform) apply true
+    alias(libs.plugins.android.library) apply true
+    alias(libs.plugins.compose.multiplatform) apply true
+
+    id("convention.publication") apply true
+}
+
+repositories {
+    mavenCentral()
+    google()
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+}
+
+group = "in.procyk.compose"
+version = libs.versions.compose.extensions.get()
+
+kotlin {
+    jvm("desktop")
+
+    androidTarget {
+        publishLibraryVariants("release")
+    }
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+    }
+
+    applyDefaultHierarchyTemplate()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.ui)
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+            implementation(compose.material3)
+
+            implementation(libs.kotlinx.datetime)
+        }
+    }
+}
+
+android {
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    namespace = "in.procyk.compose.calendar"
+
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlin {
+        jvmToolchain(17)
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/Calendar.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/Calendar.kt
@@ -1,0 +1,287 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import `in`.procyk.compose.calendar.day.DayState
+import `in`.procyk.compose.calendar.day.DefaultDay
+import `in`.procyk.compose.calendar.header.DefaultMonthHeader
+import `in`.procyk.compose.calendar.header.MonthState
+import `in`.procyk.compose.calendar.month.MonthContent
+import `in`.procyk.compose.calendar.month.MonthPager
+import `in`.procyk.compose.calendar.selection.DynamicSelectionState
+import `in`.procyk.compose.calendar.selection.EmptySelectionState
+import `in`.procyk.compose.calendar.selection.SelectionMode
+import `in`.procyk.compose.calendar.selection.SelectionState
+import `in`.procyk.compose.calendar.util.now
+import `in`.procyk.compose.calendar.week.DaysInAWeek
+import `in`.procyk.compose.calendar.week.DefaultDaysOfWeekHeader
+import `in`.procyk.compose.calendar.week.rotateRight
+import `in`.procyk.compose.calendar.year.YearMonth
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+
+/**
+ * State of the calendar composable
+ *
+ * @property monthState currently showed month
+ * @property selectionState handler for the calendar's selection
+ */
+@Stable
+class CalendarState<T : SelectionState>(
+    val monthState: MonthState,
+    val selectionState: T,
+)
+
+/**
+ * [Calendar] implementation using a [DynamicSelectionState] as a selection handler.
+ *
+ *  * Basic usage:
+ * ```
+ *  @Composable
+ *  fun MainScreen() {
+ *    SelectableCalendar()
+ *  }
+ * ```
+ *
+ * @param modifier
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param today current day, defaults to [LocalDate.now]
+ * @param showAdjacentMonths whenever to show or hide the days from adjacent months
+ * @param horizontalSwipeEnabled whenever user is able to change the month by horizontal swipe
+ * @param weekDaysScrollEnabled if the week days should be scrollable
+ * @param calendarState state of the composable
+ * @param dayContent composable rendering the current day
+ * @param monthHeader header for showing the current month and controls for changing it
+ * @param daysOfWeekHeader header for showing captions for each day of week
+ * @param monthContainer container composable for all the days in current month
+ */
+@Composable
+fun SelectableCalendar(
+    modifier: Modifier = Modifier,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    today: LocalDate = LocalDate.now(),
+    showAdjacentMonths: Boolean = true,
+    horizontalSwipeEnabled: Boolean = true,
+    weekDaysScrollEnabled: Boolean = true,
+    calendarState: CalendarState<DynamicSelectionState> = rememberSelectableCalendarState(),
+    dayContent: @Composable BoxScope.(DayState<DynamicSelectionState>) -> Unit = { DefaultDay(it) },
+    monthHeader: @Composable ColumnScope.(MonthState) -> Unit = { DefaultMonthHeader(it) },
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultDaysOfWeekHeader(it) },
+    monthContainer: @Composable (content: @Composable (PaddingValues) -> Unit) -> Unit = { content ->
+        Box { content(PaddingValues()) }
+    },
+) {
+    Calendar(
+        modifier = modifier,
+        firstDayOfWeek = firstDayOfWeek,
+        today = today,
+        showAdjacentMonths = showAdjacentMonths,
+        horizontalSwipeEnabled = horizontalSwipeEnabled,
+        weekDaysScrollEnabled = weekDaysScrollEnabled,
+        calendarState = calendarState,
+        dayContent = dayContent,
+        monthHeader = monthHeader,
+        daysOfWeekHeader = daysOfWeekHeader,
+        monthContainer = monthContainer
+    )
+}
+
+/**
+ * [Calendar] implementation without any mechanism for the selection.
+ *
+ * Basic usage:
+ * ```
+ *  @Composable
+ *  fun MainScreen() {
+ *    StaticCalendar()
+ *  }
+ * ```
+ *
+ * @param modifier
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param today current day, defaults to [LocalDate.now]
+ * @param showAdjacentMonths whenever to show or hide the days from adjacent months
+ * @param horizontalSwipeEnabled whenever user is able to change the month by horizontal swipe
+ * @param weekDaysScrollEnabled if the week days should be scrollable
+ * @param calendarState state of the composable
+ * @param dayContent composable rendering the current day
+ * @param monthHeader header for showing the current month and controls for changing it
+ * @param daysOfWeekHeader header for showing captions for each day of week
+ * @param monthContainer container composable for all the days in current month
+ */
+@Composable
+fun StaticCalendar(
+    modifier: Modifier = Modifier,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    today: LocalDate = LocalDate.now(),
+    showAdjacentMonths: Boolean = true,
+    horizontalSwipeEnabled: Boolean = true,
+    weekDaysScrollEnabled: Boolean = true,
+    calendarState: CalendarState<EmptySelectionState> = rememberCalendarState(),
+    dayContent: @Composable BoxScope.(DayState<EmptySelectionState>) -> Unit = { DefaultDay(it) },
+    monthHeader: @Composable ColumnScope.(MonthState) -> Unit = { DefaultMonthHeader(it) },
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultDaysOfWeekHeader(it) },
+    monthContainer: @Composable (content: @Composable (PaddingValues) -> Unit) -> Unit = { content ->
+        Box { content(PaddingValues()) }
+    },
+) {
+    Calendar(
+        modifier = modifier,
+        firstDayOfWeek = firstDayOfWeek,
+        today = today,
+        showAdjacentMonths = showAdjacentMonths,
+        horizontalSwipeEnabled = horizontalSwipeEnabled,
+        weekDaysScrollEnabled = weekDaysScrollEnabled,
+        calendarState = calendarState,
+        dayContent = dayContent,
+        monthHeader = monthHeader,
+        daysOfWeekHeader = daysOfWeekHeader,
+        monthContainer = monthContainer
+    )
+}
+
+/**
+ * Composable for showing a calendar. The calendar state has to be provided by the call site. If you
+ * want to use built-in implementation, check out:
+ * [SelectableCalendar] - calendar composable handling selection that can be changed at runtime
+ * [StaticCalendar] - calendar without any mechanism for selection
+ *
+ * @param modifier
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param today current day, defaults to [LocalDate.now]
+ * @param showAdjacentMonths whenever to show or hide the days from adjacent months
+ * @param horizontalSwipeEnabled whenever user is able to change the month by horizontal swipe
+ * @param calendarState state of the composable
+ * @param dayContent composable rendering the current day
+ * @param monthHeader header for showing the current month and controls for changing it
+ * @param daysOfWeekHeader header for showing captions for each day of week
+ * @param monthContainer container composable for all the days in current month
+ */
+@Composable
+fun <T : SelectionState> Calendar(
+    calendarState: CalendarState<T>,
+    modifier: Modifier = Modifier,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    today: LocalDate = LocalDate.now(),
+    showAdjacentMonths: Boolean = true,
+    horizontalSwipeEnabled: Boolean = true,
+    weekDaysScrollEnabled: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState<T>) -> Unit = { DefaultDay(it) },
+    monthHeader: @Composable ColumnScope.(MonthState) -> Unit = { DefaultMonthHeader(it) },
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultDaysOfWeekHeader(it) },
+    monthContainer: @Composable (content: @Composable (PaddingValues) -> Unit) -> Unit = { content ->
+        Box { content(PaddingValues()) }
+    },
+) {
+    val initialMonth = remember { calendarState.monthState.currentMonth }
+    val daysOfWeek = remember(firstDayOfWeek) {
+        DayOfWeek.entries.rotateRight(DaysInAWeek - firstDayOfWeek.ordinal)
+    }
+
+    Column(
+        modifier = modifier,
+    ) {
+        monthHeader(calendarState.monthState)
+        if (horizontalSwipeEnabled) {
+            MonthPager(
+                initialMonth = initialMonth,
+                showAdjacentMonths = showAdjacentMonths,
+                monthState = calendarState.monthState,
+                selectionState = calendarState.selectionState,
+                today = today,
+                weekDaysScrollEnabled = weekDaysScrollEnabled,
+                daysOfWeek = daysOfWeek,
+                dayContent = dayContent,
+                weekHeader = daysOfWeekHeader,
+                monthContainer = monthContainer,
+            )
+        } else {
+            MonthContent(
+                modifier = Modifier.fillMaxWidth(),
+                currentMonth = calendarState.monthState.currentMonth,
+                showAdjacentMonths = showAdjacentMonths,
+                selectionState = calendarState.selectionState,
+                today = today,
+                weekDaysScrollEnabled = weekDaysScrollEnabled,
+                daysOfWeek = daysOfWeek,
+                dayContent = dayContent,
+                weekHeader = daysOfWeekHeader,
+                monthContainer = monthContainer,
+            )
+        }
+    }
+}
+
+/**
+ * Helper function for providing a [CalendarState] implementation with selection mechanism.
+ *
+ * @param initialMonth initially rendered month
+ * @param initialSelection initial selection of the composable
+ * @param initialSelectionMode initial mode of the selection
+ * @param confirmSelectionChange callback for optional side-effects handling and vetoing the state change
+ * @param minMonth first month that can be shown
+ * @param maxMonth last month that can be shown
+ */
+@Composable
+fun rememberSelectableCalendarState(
+    initialMonth: YearMonth = YearMonth.now(),
+    minMonth: YearMonth = initialMonth.minusMonths(DefaultCalendarPagerRange),
+    maxMonth: YearMonth = initialMonth.plusMonths(DefaultCalendarPagerRange),
+    initialSelection: List<LocalDate> = emptyList(),
+    initialSelectionMode: SelectionMode = SelectionMode.Single,
+    confirmSelectionChange: (newValue: List<LocalDate>) -> Boolean = { true },
+    monthState: MonthState = rememberSaveable(saver = MonthState.Saver()) {
+        MonthState(
+            initialMonth = initialMonth,
+            minMonth = minMonth,
+            maxMonth = maxMonth
+        )
+    },
+    selectionState: DynamicSelectionState = rememberSaveable(
+        saver = DynamicSelectionState.Saver(confirmSelectionChange),
+    ) {
+        DynamicSelectionState(confirmSelectionChange, initialSelection, initialSelectionMode)
+    },
+): CalendarState<DynamicSelectionState> = remember { CalendarState(monthState, selectionState) }
+
+/**
+ * Helper function for providing a [CalendarState] implementation without a selection mechanism.
+ *
+ * @param initialMonth initially rendered month
+ * @param minMonth first month that can be shown
+ * @param maxMonth last month that can be shown
+ */
+@Composable
+fun rememberCalendarState(
+    initialMonth: YearMonth = YearMonth.now(),
+    minMonth: YearMonth = initialMonth.minusMonths(DefaultCalendarPagerRange),
+    maxMonth: YearMonth = initialMonth.plusMonths(DefaultCalendarPagerRange),
+    monthState: MonthState = rememberSaveable(saver = MonthState.Saver()) {
+        MonthState(
+            initialMonth = initialMonth,
+            minMonth = minMonth,
+            maxMonth = maxMonth
+        )
+    },
+): CalendarState<EmptySelectionState> = remember { CalendarState(monthState, EmptySelectionState) }
+
+internal const val DefaultCalendarPagerRange = 10_000L

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/WeekCalendar.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/WeekCalendar.kt
@@ -1,0 +1,265 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
+import `in`.procyk.compose.calendar.day.DayState
+import `in`.procyk.compose.calendar.day.DefaultDay
+import `in`.procyk.compose.calendar.header.WeekState
+import `in`.procyk.compose.calendar.selection.DynamicSelectionState
+import `in`.procyk.compose.calendar.selection.EmptySelectionState
+import `in`.procyk.compose.calendar.selection.SelectionMode
+import `in`.procyk.compose.calendar.selection.SelectionState
+import `in`.procyk.compose.calendar.util.now
+import `in`.procyk.compose.calendar.week.*
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import `in`.procyk.compose.calendar.header.DefaultWeekHeader as DefaultProperWeekHeader
+
+/**
+ * State of the week calendar composable
+ *
+ * @property weekState currently showed week
+ * @property selectionState handler for the calendar's selection
+ */
+@Stable
+class WeekCalendarState<T : SelectionState>(
+    val weekState: WeekState,
+    val selectionState: T,
+)
+
+/**
+ * [WeekCalendar] implementation using a [DynamicSelectionState] as a selection handler.
+ *
+ *  * Basic usage:
+ * ```
+ *  @Composable
+ *  fun MainScreen() {
+ *    SelectableWeekCalendar()
+ *  }
+ * ```
+ *
+ * @param modifier
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param today current day, defaults to [LocalDate.now]
+ * @param horizontalSwipeEnabled whenever user is able to change the week by horizontal swipe
+ * @param weekDaysScrollEnabled if the week days should be scrollable
+ * @param calendarState state of the composable
+ * @param dayContent composable rendering the current day
+ * @param weekHeader header for showing the current week and controls for changing it
+ * @param daysOfWeekHeader header for showing captions for each day of week
+ */
+@Composable
+fun SelectableWeekCalendar(
+    modifier: Modifier = Modifier,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    today: LocalDate = LocalDate.now(),
+    horizontalSwipeEnabled: Boolean = true,
+    weekDaysScrollEnabled: Boolean = true,
+    calendarState: WeekCalendarState<DynamicSelectionState> = rememberSelectableWeekCalendarState(),
+    dayContent: @Composable BoxScope.(DayState<DynamicSelectionState>) -> Unit = { DefaultDay(it) },
+    weekHeader: @Composable ColumnScope.(WeekState) -> Unit = {
+        DefaultProperWeekHeader(it)
+    },
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultDaysOfWeekHeader(it) },
+) {
+    WeekCalendar(
+        modifier = modifier,
+        calendarState = calendarState,
+        today = today,
+        horizontalSwipeEnabled = horizontalSwipeEnabled,
+        firstDayOfWeek = firstDayOfWeek,
+        weekDaysScrollEnabled = weekDaysScrollEnabled,
+        dayContent = dayContent,
+        weekHeader = weekHeader,
+        daysOfWeekHeader = daysOfWeekHeader,
+    )
+}
+
+/**
+ * [WeekCalendar] implementation without any mechanism for the selection.
+ *
+ *  * Basic usage:
+ * ```
+ *  @Composable
+ *  fun MainScreen() {
+ *    StaticWeekCalendar()
+ *  }
+ * ```
+ *
+ * @param modifier
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param today current day, defaults to [LocalDate.now]
+ * @param horizontalSwipeEnabled whenever user is able to change the week by horizontal swipe
+ * @param calendarState state of the composable
+ * @param dayContent composable rendering the current day
+ * @param weekHeader header for showing the current week and controls for changing it
+ * @param daysOfWeekHeader header for showing captions for each day of week
+ */
+@Composable
+fun StaticWeekCalendar(
+    modifier: Modifier = Modifier,
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    today: LocalDate = LocalDate.now(),
+    horizontalSwipeEnabled: Boolean = true,
+    calendarState: WeekCalendarState<EmptySelectionState> = rememberWeekCalendarState(),
+    weekDaysScrollEnabled: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState<EmptySelectionState>) -> Unit = { DefaultDay(it) },
+    weekHeader: @Composable ColumnScope.(WeekState) -> Unit = {
+        DefaultProperWeekHeader(it)
+    },
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultDaysOfWeekHeader(it) },
+) {
+    WeekCalendar(
+        modifier = modifier,
+        calendarState = calendarState,
+        today = today,
+        horizontalSwipeEnabled = horizontalSwipeEnabled,
+        firstDayOfWeek = firstDayOfWeek,
+        weekDaysScrollEnabled = weekDaysScrollEnabled,
+        dayContent = dayContent,
+        weekHeader = weekHeader,
+        daysOfWeekHeader = daysOfWeekHeader,
+    )
+}
+
+/**
+ * Composable for showing a week calendar. The calendar state has to be provided by the call site. If you
+ * want to use built-in implementation, check out:
+ * [SelectableWeekCalendar] - calendar composable handling selection that can be changed at runtime
+ * [StaticWeekCalendar] - calendar without any mechanism for selection
+ *
+ * @param modifier
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param today current day, defaults to [LocalDate.now]
+ * @param horizontalSwipeEnabled whenever user is able to change the week by horizontal swipe
+ * @param calendarState state of the composable
+ * @param dayContent composable rendering the current day
+ * @param weekHeader header for showing the current week and controls for changing it
+ * @param daysOfWeekHeader header for showing captions for each day of week
+ */
+@Composable
+fun <T : SelectionState> WeekCalendar(
+    calendarState: WeekCalendarState<T>,
+    modifier: Modifier = Modifier,
+    today: LocalDate = LocalDate.now(),
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    horizontalSwipeEnabled: Boolean = true,
+    weekDaysScrollEnabled: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState<T>) -> Unit = { DefaultDay(it) },
+    weekHeader: @Composable ColumnScope.(WeekState) -> Unit = {
+        DefaultProperWeekHeader(it)
+    },
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit = { DefaultDaysOfWeekHeader(it) },
+) {
+    val initialWeek = remember { calendarState.weekState.currentWeek }
+    val daysOfWeek = remember(firstDayOfWeek) {
+        DayOfWeek.entries.rotateRight(DaysInAWeek - firstDayOfWeek.ordinal)
+    }
+
+    Column(
+        modifier = modifier,
+    ) {
+        weekHeader(calendarState.weekState)
+        if (horizontalSwipeEnabled) {
+            WeekPager(
+                initialWeek = initialWeek,
+                daysOfWeek = daysOfWeek,
+                weekState = calendarState.weekState,
+                selectionState = calendarState.selectionState,
+                today = today,
+                weekDaysScrollEnabled = weekDaysScrollEnabled,
+                dayContent = dayContent,
+                daysOfWeekHeader = daysOfWeekHeader,
+            )
+        } else {
+            WeekContent(
+                daysOfWeek = daysOfWeek,
+                weekDays = calendarState.weekState.currentWeek.getWeekDays(today),
+                selectionState = calendarState.selectionState,
+                weekDaysScrollEnabled = weekDaysScrollEnabled,
+                dayContent = dayContent,
+                daysOfWeekHeader = daysOfWeekHeader,
+            )
+        }
+    }
+}
+
+/**
+ * Helper function for providing a [WeekCalendarState] implementation with selection mechanism.
+ *
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param initialWeek initially rendered month
+ * @param initialSelection initial selection of the composable
+ * @param initialSelectionMode initial mode of the selection
+ * @param confirmSelectionChange callback for optional side-effects handling and vetoing the state change
+ * @param minWeek first week that can be shown
+ * @param maxWeek last week that can be shown
+ */
+@Composable
+fun rememberSelectableWeekCalendarState(
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    initialWeek: Week = Week.now(firstDayOfWeek),
+    minWeek: Week = initialWeek.minusWeeks(DefaultCalendarPagerRange),
+    maxWeek: Week = initialWeek.plusWeeks(DefaultCalendarPagerRange),
+    initialSelection: List<LocalDate> = emptyList(),
+    initialSelectionMode: SelectionMode = SelectionMode.Single,
+    confirmSelectionChange: (newValue: List<LocalDate>) -> Boolean = { true },
+    weekState: WeekState = rememberSaveable(saver = WeekState.Saver()) {
+        WeekState(
+            initialWeek = initialWeek,
+            minWeek = minWeek,
+            maxWeek = maxWeek,
+        )
+    },
+    selectionState: DynamicSelectionState = rememberSaveable(
+        saver = DynamicSelectionState.Saver(confirmSelectionChange),
+    ) {
+        DynamicSelectionState(confirmSelectionChange, initialSelection, initialSelectionMode)
+    },
+): WeekCalendarState<DynamicSelectionState> =
+    remember { WeekCalendarState(weekState, selectionState) }
+
+/**
+ * Helper function for providing a [WeekCalendarState] implementation without a selection mechanism.
+ *
+ * @param firstDayOfWeek first day of a week, defaults to current locale's
+ * @param initialWeek initially rendered week
+ * @param minWeek first week that can be shown
+ * @param maxWeek last week that can be shown
+ */
+@Composable
+fun rememberWeekCalendarState(
+    firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY,
+    initialWeek: Week = Week.now(firstDayOfWeek),
+    minWeek: Week = initialWeek.minusWeeks(DefaultCalendarPagerRange),
+    maxWeek: Week = initialWeek.plusWeeks(DefaultCalendarPagerRange),
+    weekState: WeekState = rememberSaveable(saver = WeekState.Saver()) {
+        WeekState(
+            initialWeek = initialWeek,
+            minWeek = minWeek,
+            maxWeek = maxWeek,
+        )
+    },
+): WeekCalendarState<EmptySelectionState> =
+    remember { WeekCalendarState(weekState, EmptySelectionState) }

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/Day.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/Day.kt
@@ -1,0 +1,31 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.day
+
+import kotlinx.datetime.LocalDate
+
+/**
+ * Container for basic info about the displayed day
+ *
+ * @param date local date of the day
+ * @param isCurrentDay whenever the day is the today's date
+ * @param isFromCurrentMonth whenever the day is from currently rendered month
+ */
+interface Day {
+    val date: LocalDate
+    val isCurrentDay: Boolean
+    val isFromCurrentMonth: Boolean
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/DayState.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/DayState.kt
@@ -1,0 +1,31 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.day
+
+import androidx.compose.runtime.Stable
+import `in`.procyk.compose.calendar.selection.EmptySelectionState
+import `in`.procyk.compose.calendar.selection.SelectionState
+
+typealias NonSelectableDayState = DayState<EmptySelectionState>
+
+/**
+ * Contains information about current selection as well as date of rendered day
+ */
+@Stable
+data class DayState<T : SelectionState>(
+    private val day: Day,
+    val selectionState: T,
+) : Day by day

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/DefaultDay.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/DefaultDay.kt
@@ -1,0 +1,79 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.day
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import `in`.procyk.compose.calendar.selection.SelectionState
+import kotlinx.datetime.LocalDate
+
+/**
+ * Default implementation for day content. It supports different appearance for days from
+ * current and adjacent month, as well as current day and selected day
+ *
+ * @param selectionColor color of the border, when day is selected
+ * @param currentDayColor color of content for the current date
+ * @param onClick callback for interacting with day clicks
+ */
+@Composable
+fun <T : SelectionState> DefaultDay(
+    state: DayState<T>,
+    modifier: Modifier = Modifier,
+    selectionColor: Color = MaterialTheme.colorScheme.secondary,
+    currentDayColor: Color = MaterialTheme.colorScheme.primary,
+    onClick: (LocalDate) -> Unit = {},
+) {
+    val date = state.date
+    val selectionState = state.selectionState
+
+    val isSelected = selectionState.isDateSelected(date)
+
+    Card(
+        modifier = modifier
+            .alpha(if (state.isFromCurrentMonth) 1f else 0.5f)
+            .aspectRatio(1f)
+            .padding(2.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (state.isFromCurrentMonth) 2.dp else 0.dp),
+        border = if (state.isCurrentDay) BorderStroke(1.dp, currentDayColor) else null,
+        colors = CardDefaults.cardColors(containerColor = if (isSelected) selectionColor else Color.Unspecified),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable {
+                    onClick(date)
+                    selectionState.onDateSelected(date)
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(text = date.dayOfMonth.toString())
+        }
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/WeekDay.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/day/WeekDay.kt
@@ -1,0 +1,26 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.day
+
+import androidx.compose.runtime.Immutable
+import kotlinx.datetime.LocalDate
+
+@Immutable
+internal class WeekDay(
+    override val date: LocalDate,
+    override val isCurrentDay: Boolean,
+    override val isFromCurrentMonth: Boolean,
+) : Day

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/DefaultMonthHeader.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/DefaultMonthHeader.kt
@@ -1,0 +1,105 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.header
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.Month
+
+/**
+ * Default implementation of month header, shows current month and year, as well as
+ * 2 arrows for changing currently showed month
+ */
+@Composable
+fun DefaultMonthHeader(
+    monthState: MonthState,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        DecrementButton(monthState = monthState)
+        Spacer(modifier.weight(1f))
+        Text(
+            modifier = Modifier.testTag("MonthLabel"),
+            text = Month(monthState.currentMonth.month)
+                .name
+                .lowercase()
+                .replaceFirstChar { it.titlecase() },
+            style = MaterialTheme.typography.headlineMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = monthState.currentMonth.year.toString(),
+            style = MaterialTheme.typography.headlineMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier.weight(1f))
+        IncrementButton(monthState = monthState)
+    }
+}
+
+@Composable
+private fun DecrementButton(
+    monthState: MonthState,
+) {
+    IconButton(
+        modifier = Modifier.testTag("Decrement"),
+        enabled = monthState.currentMonth > monthState.minMonth,
+        onClick = { monthState.currentMonth = monthState.currentMonth.minusMonths(1) }
+    ) {
+        Image(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+            contentDescription = "Previous",
+        )
+    }
+}
+
+@Composable
+private fun IncrementButton(
+    monthState: MonthState,
+) {
+    IconButton(
+        modifier = Modifier.testTag("Increment"),
+        enabled = monthState.currentMonth < monthState.maxMonth,
+        onClick = { monthState.currentMonth = monthState.currentMonth.plusMonths(1) }
+    ) {
+        Image(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+            contentDescription = "Next",
+        )
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/DefaultWeekHeader.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/DefaultWeekHeader.kt
@@ -1,0 +1,105 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.header
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.Month
+
+/**
+ * Default implementation of week header, shows current month and year, as well as
+ * 2 arrows for changing currently showed month
+ */
+@Composable
+fun DefaultWeekHeader(
+    weekState: WeekState,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        DecrementButton(weekState = weekState)
+        Spacer(modifier.weight(1f))
+        Text(
+            modifier = Modifier.testTag("WeekLabel"),
+            text = Month(weekState.currentWeek.yearMonth.month)
+                .name
+                .lowercase()
+                .replaceFirstChar { it.titlecase() },
+            style = MaterialTheme.typography.headlineMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = weekState.currentWeek.yearMonth.year.toString(),
+            style = MaterialTheme.typography.headlineMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier.weight(1f))
+        IncrementButton(monthState = weekState)
+    }
+}
+
+@Composable
+private fun DecrementButton(
+    weekState: WeekState,
+) {
+    IconButton(
+        modifier = Modifier.testTag("Decrement"),
+        enabled = weekState.currentWeek > weekState.minWeek,
+        onClick = { weekState.currentWeek = weekState.currentWeek.dec() }
+    ) {
+        Image(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+            contentDescription = "Previous",
+        )
+    }
+}
+
+@Composable
+private fun IncrementButton(
+    monthState: WeekState,
+) {
+    IconButton(
+        modifier = Modifier.testTag("Increment"),
+        enabled = monthState.currentWeek < monthState.maxWeek,
+        onClick = { monthState.currentWeek = monthState.currentWeek.inc() }
+    ) {
+        Image(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+            contentDescription = "Next",
+        )
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/MonthState.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/MonthState.kt
@@ -1,0 +1,88 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.header
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.runtime.setValue
+import `in`.procyk.compose.calendar.year.YearMonth
+
+fun MonthState(
+    initialMonth: YearMonth,
+    minMonth: YearMonth,
+    maxMonth: YearMonth,
+): MonthState = MonthStateImpl(initialMonth, minMonth, maxMonth)
+
+@Stable
+interface MonthState {
+    var currentMonth: YearMonth
+    var minMonth: YearMonth
+    var maxMonth: YearMonth
+
+    companion object {
+        fun Saver(): Saver<MonthState, Any> = mapSaver(
+            save = { monthState ->
+                mapOf(
+                    "currentMonth" to monthState.currentMonth.toString(),
+                    "minMonth" to monthState.minMonth.toString(),
+                    "maxMonth" to monthState.maxMonth.toString(),
+                )
+            },
+            restore = { restoreMap ->
+                MonthState(
+                    YearMonth.parse(restoreMap["currentMonth"] as String)!!,
+                    YearMonth.parse(restoreMap["minMonth"] as String)!!,
+                    YearMonth.parse(restoreMap["maxMonth"] as String)!!,
+                )
+            }
+        )
+    }
+}
+
+@Stable
+private class MonthStateImpl(
+    initialMonth: YearMonth,
+    minMonth: YearMonth,
+    maxMonth: YearMonth,
+) : MonthState {
+
+    private var _currentMonth by mutableStateOf(initialMonth)
+    private var _minMonth by mutableStateOf(minMonth)
+    private var _maxMonth by mutableStateOf(maxMonth)
+
+    override var currentMonth: YearMonth
+        get() = _currentMonth
+        set(value) {
+            _currentMonth = value
+        }
+
+    override var minMonth: YearMonth
+        get() = _minMonth
+        set(value) {
+            if (value > _maxMonth) return
+            _minMonth = value
+        }
+
+    override var maxMonth: YearMonth
+        get() = _maxMonth
+        set(value) {
+            if (value < _minMonth) return
+            _maxMonth = value
+        }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/WeekState.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/header/WeekState.kt
@@ -1,0 +1,97 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.header
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.runtime.setValue
+import `in`.procyk.compose.calendar.week.Week
+import kotlinx.datetime.LocalDate
+
+fun WeekState(
+    initialWeek: Week,
+    minWeek: Week,
+    maxWeek: Week,
+): WeekState = WeekStateImpl(
+    initialWeek = initialWeek,
+    minWeek = minWeek,
+    maxWeek = maxWeek,
+)
+
+@Stable
+interface WeekState {
+    var currentWeek: Week
+    var minWeek: Week
+    var maxWeek: Week
+
+    companion object {
+        fun Saver(): Saver<WeekState, Any> = mapSaver(
+            save = { weekState ->
+                mapOf(
+                    CurrentWeekKey to weekState.currentWeek.toString(),
+                    MinWeekKey to weekState.minWeek.toString(),
+                    MaxWeekKey to weekState.maxWeek.toString(),
+                )
+            },
+            restore = { restoreMap ->
+                WeekState(
+                    initialWeek = Week(firstDay = LocalDate.parse(restoreMap[CurrentWeekKey] as String)),
+                    minWeek = Week(firstDay = LocalDate.parse(restoreMap[MinWeekKey] as String)),
+                    maxWeek = Week(firstDay = LocalDate.parse(restoreMap[MaxWeekKey] as String)),
+                )
+            }
+        )
+
+        private const val CurrentWeekKey = "CurrentWeek"
+        private const val MinWeekKey = "MinWeek"
+        private const val MaxWeekKey = "MaxWeek"
+    }
+}
+
+@Stable
+private class WeekStateImpl(
+    initialWeek: Week,
+    minWeek: Week,
+    maxWeek: Week,
+) : WeekState {
+
+    private var _currentWeek by mutableStateOf(initialWeek)
+    private var _minWeek by mutableStateOf(minWeek)
+    private var _maxWeek by mutableStateOf(maxWeek)
+
+    override var currentWeek: Week
+        get() = _currentWeek
+        set(value) {
+            _currentWeek = value
+        }
+
+    override var minWeek: Week
+        get() = _minWeek
+        set(value) {
+            if (value > _maxWeek) return
+            _minWeek = value
+        }
+
+    override var maxWeek: Week
+        get() = _maxWeek
+        set(value) {
+            if (value < _minWeek) return
+            _maxWeek = value
+        }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/month/MonthContent.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/month/MonthContent.kt
@@ -1,0 +1,168 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.month
+
+import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import `in`.procyk.compose.calendar.day.DayState
+import `in`.procyk.compose.calendar.header.MonthState
+import `in`.procyk.compose.calendar.selection.SelectionState
+import `in`.procyk.compose.calendar.util.SnapOffsets
+import `in`.procyk.compose.calendar.util.SnapperFlingBehaviorDefaults
+import `in`.procyk.compose.calendar.util.SnapperLayoutInfo
+import `in`.procyk.compose.calendar.util.rememberSnapperFlingBehavior
+import `in`.procyk.compose.calendar.week.WeekRow
+import `in`.procyk.compose.calendar.week.getWeeks
+import `in`.procyk.compose.calendar.year.YearMonth
+import `in`.procyk.compose.calendar.year.YearMonth.Companion.monthsBetween
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+
+@Composable
+@Suppress("LongMethod")
+internal fun <T : SelectionState> MonthPager(
+    initialMonth: YearMonth,
+    showAdjacentMonths: Boolean,
+    selectionState: T,
+    monthState: MonthState,
+    daysOfWeek: List<DayOfWeek>,
+    today: LocalDate,
+    modifier: Modifier = Modifier,
+    weekDaysScrollEnabled: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState<T>) -> Unit,
+    weekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit,
+    monthContainer: @Composable (content: @Composable (PaddingValues) -> Unit) -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    val initialFirstVisibleItemIndex = remember(initialMonth, monthState.minMonth) {
+        monthsBetween(monthState.minMonth, initialMonth).toInt()
+    }
+    val listState = rememberLazyListState(
+        initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
+    )
+    val flingBehavior = rememberSnapperFlingBehavior(
+        lazyListState = listState,
+        snapOffsetForItem = SnapOffsets.Start,
+        springAnimationSpec = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+        decayAnimationSpec = rememberSplineBasedDecay(),
+        snapIndex = coerceSnapIndex,
+    )
+
+    val monthListState = remember {
+        MonthListState(
+            coroutineScope = coroutineScope,
+            monthState = monthState,
+            listState = listState,
+        )
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (weekDaysScrollEnabled.not()) {
+            Box(
+                modifier = Modifier
+                    .wrapContentHeight()
+                    .fillMaxWidth(),
+                content = { weekHeader(daysOfWeek) },
+            )
+        }
+        val pagerCount = remember(monthState.minMonth, monthState.maxMonth) {
+            monthsBetween(monthState.minMonth, monthState.maxMonth).toInt() + 1
+        }
+        LazyRow(
+            modifier = modifier.testTag("MonthPager"),
+            state = listState,
+            flingBehavior = flingBehavior,
+            verticalAlignment = Alignment.Top,
+        ) {
+            items(
+                count = pagerCount,
+                key = { index ->
+                    monthListState.getMonthForPage(index).let { "${it.year}-${it.month}" }
+                }
+            ) { index ->
+                MonthContent(
+                    modifier = Modifier.fillParentMaxWidth(),
+                    showAdjacentMonths = showAdjacentMonths,
+                    selectionState = selectionState,
+                    currentMonth = monthListState.getMonthForPage(index),
+                    today = today,
+                    weekDaysScrollEnabled = weekDaysScrollEnabled,
+                    daysOfWeek = daysOfWeek,
+                    dayContent = dayContent,
+                    weekHeader = weekHeader,
+                    monthContainer = monthContainer
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun <T : SelectionState> MonthContent(
+    showAdjacentMonths: Boolean,
+    selectionState: T,
+    currentMonth: YearMonth,
+    daysOfWeek: List<DayOfWeek>,
+    today: LocalDate,
+    modifier: Modifier = Modifier,
+    weekDaysScrollEnabled: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState<T>) -> Unit,
+    weekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit,
+    monthContainer: @Composable (content: @Composable (PaddingValues) -> Unit) -> Unit,
+) {
+    Column {
+        if (weekDaysScrollEnabled) {
+            Box(
+                modifier = modifier
+                    .wrapContentHeight(),
+                content = { weekHeader(daysOfWeek) },
+            )
+        }
+        monthContainer { paddingValues ->
+            Column(
+                modifier = modifier
+                    .padding(paddingValues)
+            ) {
+                currentMonth.getWeeks(
+                    includeAdjacentMonths = showAdjacentMonths,
+                    firstDayOfTheWeek = daysOfWeek.first(),
+                    today = today,
+                ).forEach { week ->
+                    WeekRow(
+                        weekDays = week,
+                        selectionState = selectionState,
+                        dayContent = dayContent,
+                    )
+                }
+            }
+        }
+    }
+}
+
+internal val coerceSnapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int =
+    { _, startIndex, targetIndex ->
+        targetIndex
+            .coerceIn(startIndex - 1, startIndex + 1)
+    }

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/month/MonthListState.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/month/MonthListState.kt
@@ -1,0 +1,82 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.month
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
+import `in`.procyk.compose.calendar.header.MonthState
+import `in`.procyk.compose.calendar.util.throttleOnOffset
+import `in`.procyk.compose.calendar.year.YearMonth
+import `in`.procyk.compose.calendar.year.YearMonth.Companion.monthsBetween
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+@Stable
+internal class MonthListState(
+    private val coroutineScope: CoroutineScope,
+    private val monthState: MonthState,
+    private val listState: LazyListState,
+) {
+
+    private val currentFirstVisibleMonth by derivedStateOf {
+        getMonthForPage(listState.firstVisibleItemIndex)
+    }
+
+    init {
+        snapshotFlow { monthState.currentMonth }.onEach { month ->
+            moveToMonth(month)
+        }.launchIn(coroutineScope)
+
+        snapshotFlow { currentFirstVisibleMonth }
+            .throttleOnOffset(listState)
+            .onEach { newMonth ->
+                monthState.currentMonth = newMonth
+            }.launchIn(coroutineScope)
+    }
+
+    fun getMonthForPage(index: Int): YearMonth =
+        monthState.minMonth.plusMonths(index.toLong())
+
+    private fun moveToMonth(month: YearMonth) {
+        if (month == currentFirstVisibleMonth) return
+        coroutineScope.launch {
+            listState.animateScrollToItem(monthsBetween(monthState.minMonth, month).toInt())
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as MonthListState
+
+        if (monthState != other.monthState) return false
+        if (listState != other.listState) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = monthState.hashCode()
+        result = 31 * result + listState.hashCode()
+        return result
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/DynamicSelectionHandler.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/DynamicSelectionHandler.kt
@@ -1,0 +1,50 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.selection
+
+import `in`.procyk.compose.calendar.util.addOrRemoveIfExists
+import kotlinx.datetime.LocalDate
+
+
+object DynamicSelectionHandler {
+    /**
+     * Helper class for calculating new selection, when using a [DynamicSelectionState] approach.
+     * @param date clicked on date
+     * @param selection current selection
+     * @param selectionMode current selection mode
+     * @returns new selection in a form of a list of local dates.
+     */
+    fun calculateNewSelection(
+        date: LocalDate,
+        selection: List<LocalDate>,
+        selectionMode: SelectionMode,
+    ): List<LocalDate> = when (selectionMode) {
+        SelectionMode.None -> emptyList()
+        SelectionMode.Single -> if (date == selection.firstOrNull()) {
+            emptyList()
+        } else {
+            listOf(date)
+        }
+
+        SelectionMode.Multiple -> selection.addOrRemoveIfExists(date)
+        SelectionMode.Period -> when {
+            date < selection.startOrMax() -> listOf(date)
+            date > selection.startOrMax() -> selection.fillUpTo(date)
+            date == selection.startOrMax() -> emptyList()
+            else -> selection
+        }
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/SelectionExtensions.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/SelectionExtensions.kt
@@ -1,0 +1,32 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.selection
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
+import kotlinx.datetime.plus
+
+internal fun Collection<LocalDate>.startOrMax() = firstOrNull() ?: MAX_LOCAL_DATE
+
+internal fun Collection<LocalDate>.endOrNull() = drop(1).lastOrNull()
+
+internal fun Collection<LocalDate>.fillUpTo(date: LocalDate): List<LocalDate> =
+    (0..date.toEpochDays() - first().toEpochDays()).map {
+        first().plus(it, DateTimeUnit.DAY)
+    }
+
+private val MAX_LOCAL_DATE: LocalDate = LocalDate(Int.MAX_VALUE, Month.DECEMBER, 31)

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/SelectionMode.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/SelectionMode.kt
@@ -1,0 +1,30 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.selection
+
+/**
+ * Selection modes for the [DynamicSelectionState]
+ * None - no selection allowed
+ * Single - only one date selected
+ * Multiple - multiple dates can be selected
+ * Period - period can be selected
+ */
+enum class SelectionMode {
+    None,
+    Single,
+    Multiple,
+    Period,
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/SelectionState.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/selection/SelectionState.kt
@@ -1,0 +1,91 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.selection
+
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import kotlinx.datetime.LocalDate
+
+@Stable
+interface SelectionState {
+    fun isDateSelected(date: LocalDate): Boolean = false
+    fun onDateSelected(date: LocalDate) {}
+}
+
+/**
+ * Class that enables for dynamically changing selection modes in the runtime. Depending on the mode, selection changes differently.
+ * Mode can be varied by setting desired [SelectionMode] in the [selectionMode] mutable property.
+ * @param confirmSelectionChange return false from this callback to veto the selection change
+ */
+@Stable
+class DynamicSelectionState(
+    private val confirmSelectionChange: (newValue: List<LocalDate>) -> Boolean = { true },
+    selection: List<LocalDate>,
+    selectionMode: SelectionMode,
+) : SelectionState {
+
+    private var _selection by mutableStateOf(selection)
+    private var _selectionMode by mutableStateOf(selectionMode)
+
+    var selection: List<LocalDate>
+        get() = _selection
+        set(value) {
+            if (value != selection && confirmSelectionChange(value)) {
+                _selection = value
+            }
+        }
+
+    var selectionMode: SelectionMode
+        get() = _selectionMode
+        set(value) {
+            if (value != selectionMode) {
+                _selection = emptyList()
+                _selectionMode = value
+            }
+        }
+
+    override fun isDateSelected(date: LocalDate): Boolean = selection.contains(date)
+
+    override fun onDateSelected(date: LocalDate) {
+        selection = DynamicSelectionHandler.calculateNewSelection(date, selection, selectionMode)
+    }
+
+    internal companion object {
+        fun Saver(
+            confirmSelectionChange: (newValue: List<LocalDate>) -> Boolean,
+        ): Saver<DynamicSelectionState, Any> =
+            listSaver(
+                save = { raw ->
+                    listOf(raw.selectionMode, raw.selection.map { it.toString() })
+                },
+                restore = { restored ->
+                    DynamicSelectionState(
+                        confirmSelectionChange = confirmSelectionChange,
+                        selectionMode = restored[0] as SelectionMode,
+                        selection = (restored[1] as? List<*>)?.map { LocalDate.parse(it as String) }.orEmpty(),
+                    )
+                }
+            )
+    }
+}
+
+@Immutable
+object EmptySelectionState : SelectionState {
+    override fun isDateSelected(date: LocalDate): Boolean = false
+
+    override fun onDateSelected(date: LocalDate): Unit = Unit
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/util/DateUtil.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/util/DateUtil.kt
@@ -1,0 +1,30 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.util
+
+import kotlinx.datetime.*
+
+internal fun Collection<LocalDate>.addOrRemoveIfExists(date: LocalDate) =
+    if (contains(date)) {
+        this - date
+    } else {
+        this + date
+    }
+
+internal fun LocalDate.Companion.now(): LocalDate =
+    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+
+internal infix fun DayOfWeek.daysUntil(other: DayOfWeek) = (7 + (ordinal - other.ordinal)) % 7

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/util/ListStateExtensions.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/util/ListStateExtensions.kt
@@ -1,0 +1,34 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.util
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+
+internal fun <T> Flow<T>.throttleOnOffset(lazyListState: LazyListState) =
+    combine(
+        snapshotFlow { lazyListState.firstVisibleItemScrollOffset }
+    ) { newMonth, offset ->
+        newMonth to (offset <= MinimalOffsetForEmit)
+    }.filter { (_, shouldUpdate) ->
+        shouldUpdate
+    }.map { (newValue, _) -> newValue }
+
+private const val MinimalOffsetForEmit = 10

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/util/SnapperFlingBehaviorUtil.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/util/SnapperFlingBehaviorUtil.kt
@@ -1,0 +1,452 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.util
+
+import androidx.compose.animation.core.*
+import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.ScrollScope
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.*
+import kotlin.math.*
+
+@Composable
+internal fun rememberSnapperFlingBehavior(
+    lazyListState: LazyListState,
+    snapOffsetForItem: (layoutInfo: SnapperLayoutInfo, item: SnapperLayoutItemInfo) -> Int = SnapOffsets.Center,
+    decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
+    springAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+    snapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int = SnapperFlingBehaviorDefaults.SnapIndex,
+): SnapperFlingBehavior = rememberSnapperFlingBehavior(
+    layoutInfo = rememberLazyListSnapperLayoutInfo(lazyListState, snapOffsetForItem),
+    decayAnimationSpec = decayAnimationSpec,
+    springAnimationSpec = springAnimationSpec,
+    snapIndex = snapIndex,
+)
+
+@Composable
+internal fun rememberLazyListSnapperLayoutInfo(
+    lazyListState: LazyListState,
+    snapOffsetForItem: (layoutInfo: SnapperLayoutInfo, item: SnapperLayoutItemInfo) -> Int = SnapOffsets.Center,
+): LazyListSnapperLayoutInfo = remember(lazyListState, snapOffsetForItem) {
+    LazyListSnapperLayoutInfo(
+        lazyListState = lazyListState,
+        snapOffsetForItem = snapOffsetForItem,
+    )
+}
+
+internal class LazyListSnapperLayoutInfo(
+    private val lazyListState: LazyListState,
+    private val snapOffsetForItem: (layoutInfo: SnapperLayoutInfo, item: SnapperLayoutItemInfo) -> Int,
+) : SnapperLayoutInfo() {
+
+    override val startScrollOffset: Int = 0
+    override val endScrollOffset: Int
+        get() = lazyListState.layoutInfo.let { it.viewportEndOffset - it.afterContentPadding }
+    private val itemCount: Int get() = lazyListState.layoutInfo.totalItemsCount
+    override val totalItemsCount: Int
+        get() = lazyListState.layoutInfo.totalItemsCount
+    override val currentItem: SnapperLayoutItemInfo? by derivedStateOf {
+        visibleItems.lastOrNull { it.offset <= snapOffsetForItem(this, it) }
+    }
+    override val visibleItems: Sequence<SnapperLayoutItemInfo>
+        get() = lazyListState.layoutInfo.visibleItemsInfo.asSequence()
+            .map(::LazyListSnapperLayoutItemInfo)
+
+    override fun distanceToIndexSnap(index: Int): Int {
+        val itemInfo = visibleItems.firstOrNull { it.index == index }
+        if (itemInfo != null) {
+            return itemInfo.offset - snapOffsetForItem(this, itemInfo)
+        }
+        val currentItem = currentItem ?: return 0
+        return ((index - currentItem.index) * estimateDistancePerItem()).roundToInt() +
+                currentItem.offset -
+                snapOffsetForItem(this, currentItem)
+    }
+
+    override fun canScrollTowardsStart(): Boolean {
+        return lazyListState.layoutInfo.visibleItemsInfo.firstOrNull()?.let {
+            it.index > 0 || it.offset < startScrollOffset
+        } ?: false
+    }
+
+    override fun canScrollTowardsEnd(): Boolean {
+        return lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.let {
+            it.index < itemCount - 1 || (it.offset + it.size) > endScrollOffset
+        } ?: false
+    }
+
+    override fun determineTargetIndex(
+        velocity: Float,
+        decayAnimationSpec: DecayAnimationSpec<Float>,
+        maximumFlingDistance: Float,
+    ): Int {
+        val curr = currentItem ?: return -1
+        val distancePerItem = estimateDistancePerItem()
+        if (distancePerItem <= 0) {
+            return curr.index
+        }
+        val distanceToCurrent = distanceToIndexSnap(curr.index)
+        val distanceToNext = distanceToIndexSnap(curr.index + 1)
+        if (abs(velocity) < 0.5f) {
+            return when {
+                distanceToCurrent.absoluteValue < distanceToNext.absoluteValue -> curr.index
+                else -> curr.index + 1
+            }.coerceIn(0, itemCount - 1)
+        }
+        val flingDistance = decayAnimationSpec.calculateTargetValue(0f, velocity)
+            .coerceIn(-maximumFlingDistance, maximumFlingDistance)
+            .let { distance ->
+                if (velocity < 0) {
+                    (distance + distanceToNext).coerceAtMost(0f)
+                } else {
+                    (distance + distanceToCurrent).coerceAtLeast(0f)
+                }
+            }
+        val flingIndexDelta = flingDistance / distancePerItem.toDouble()
+        val currentItemOffsetRatio = distanceToCurrent / distancePerItem.toDouble()
+        val indexOffset = (flingIndexDelta - currentItemOffsetRatio).roundToInt()
+        return (curr.index + indexOffset).coerceIn(0, itemCount - 1)
+    }
+
+    private fun calculateItemSpacing(): Int = with(lazyListState.layoutInfo) {
+        if (visibleItemsInfo.size >= 2) {
+            val first = visibleItemsInfo[0]
+            val second = visibleItemsInfo[1]
+            second.offset - (first.size + first.offset)
+        } else 0
+    }
+
+    private fun estimateDistancePerItem(): Float = with(lazyListState.layoutInfo) {
+        if (visibleItemsInfo.isEmpty()) return -1f
+        val minPosView = visibleItemsInfo.minByOrNull { it.offset } ?: return -1f
+        val maxPosView = visibleItemsInfo.maxByOrNull { it.offset + it.size } ?: return -1f
+        val start = min(minPosView.offset, maxPosView.offset)
+        val end = max(minPosView.offset + minPosView.size, maxPosView.offset + maxPosView.size)
+        return when (val distance = end - start) {
+            0 -> -1f
+            else -> (distance + calculateItemSpacing()) / visibleItemsInfo.size.toFloat()
+        }
+    }
+}
+
+private class LazyListSnapperLayoutItemInfo(
+    private val lazyListItem: LazyListItemInfo,
+) : SnapperLayoutItemInfo() {
+    override val index: Int get() = lazyListItem.index
+    override val offset: Int get() = lazyListItem.offset
+    override val size: Int get() = lazyListItem.size
+}
+
+internal object SnapperFlingBehaviorDefaults {
+    internal val SpringAnimationSpec: AnimationSpec<Float> = spring(stiffness = 400f)
+
+    @Deprecated("The maximumFlingDistance parameter has been deprecated.")
+    internal val MaximumFlingDistance: (SnapperLayoutInfo) -> Float = { Float.MAX_VALUE }
+    internal val SnapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int =
+        { _, _, targetIndex -> targetIndex }
+}
+
+@Composable
+internal fun rememberSnapperFlingBehavior(
+    layoutInfo: SnapperLayoutInfo,
+    decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
+    springAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+    snapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int,
+): SnapperFlingBehavior = remember(
+    layoutInfo,
+    decayAnimationSpec,
+    springAnimationSpec,
+    snapIndex,
+) {
+    SnapperFlingBehavior(
+        layoutInfo = layoutInfo,
+        decayAnimationSpec = decayAnimationSpec,
+        springAnimationSpec = springAnimationSpec,
+        snapIndex = snapIndex,
+    )
+}
+
+internal abstract class SnapperLayoutInfo {
+    internal abstract val startScrollOffset: Int
+    internal abstract val endScrollOffset: Int
+    internal abstract val visibleItems: Sequence<SnapperLayoutItemInfo>
+    internal abstract val currentItem: SnapperLayoutItemInfo?
+    internal abstract val totalItemsCount: Int
+    internal abstract fun determineTargetIndex(
+        velocity: Float,
+        decayAnimationSpec: DecayAnimationSpec<Float>,
+        maximumFlingDistance: Float,
+    ): Int
+
+    internal abstract fun distanceToIndexSnap(index: Int): Int
+    internal abstract fun canScrollTowardsStart(): Boolean
+    internal abstract fun canScrollTowardsEnd(): Boolean
+}
+
+internal abstract class SnapperLayoutItemInfo {
+    internal abstract val index: Int
+    internal abstract val offset: Int
+    internal abstract val size: Int
+    override fun toString(): String {
+        return "SnapperLayoutItemInfo(index=$index, offset=$offset, size=$size)"
+    }
+}
+
+@Suppress("unused")
+internal object SnapOffsets {
+    internal val Start: (SnapperLayoutInfo, SnapperLayoutItemInfo) -> Int =
+        { layout, _ -> layout.startScrollOffset }
+    internal val Center: (SnapperLayoutInfo, SnapperLayoutItemInfo) -> Int = { layout, item ->
+        layout.startScrollOffset + (layout.endScrollOffset - layout.startScrollOffset - item.size) / 2
+    }
+    internal val End: (SnapperLayoutInfo, SnapperLayoutItemInfo) -> Int = { layout, item ->
+        layout.endScrollOffset - item.size
+    }
+}
+
+internal class SnapperFlingBehavior private constructor(
+    private val layoutInfo: SnapperLayoutInfo,
+    private val decayAnimationSpec: DecayAnimationSpec<Float>,
+    private val springAnimationSpec: AnimationSpec<Float>,
+    private val snapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int,
+    private val maximumFlingDistance: (SnapperLayoutInfo) -> Float,
+) : FlingBehavior {
+    internal constructor(
+        layoutInfo: SnapperLayoutInfo,
+        decayAnimationSpec: DecayAnimationSpec<Float>,
+        springAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+        snapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int = SnapperFlingBehaviorDefaults.SnapIndex,
+    ) : this(
+        layoutInfo = layoutInfo,
+        decayAnimationSpec = decayAnimationSpec,
+        springAnimationSpec = springAnimationSpec,
+        snapIndex = snapIndex,
+        maximumFlingDistance = @Suppress("DEPRECATION") SnapperFlingBehaviorDefaults.MaximumFlingDistance,
+    )
+
+    @Deprecated("The maximumFlingDistance parameter has been replaced with snapIndex")
+    @Suppress("DEPRECATION")
+    internal constructor(
+        layoutInfo: SnapperLayoutInfo,
+        decayAnimationSpec: DecayAnimationSpec<Float>,
+        springAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+        maximumFlingDistance: (SnapperLayoutInfo) -> Float = SnapperFlingBehaviorDefaults.MaximumFlingDistance,
+    ) : this(
+        layoutInfo = layoutInfo,
+        decayAnimationSpec = decayAnimationSpec,
+        springAnimationSpec = springAnimationSpec,
+        maximumFlingDistance = maximumFlingDistance,
+        snapIndex = SnapperFlingBehaviorDefaults.SnapIndex,
+    )
+
+    private var animationTarget: Int? by mutableStateOf(null)
+        private set
+
+    override suspend fun ScrollScope.performFling(
+        initialVelocity: Float,
+    ): Float {
+        if (!layoutInfo.canScrollTowardsStart() || !layoutInfo.canScrollTowardsEnd()) {
+            return initialVelocity
+        }
+        val maxFlingDistance = maximumFlingDistance(layoutInfo)
+        require(maxFlingDistance > 0) {
+            "Distance returned by maximumFlingDistance should be greater than 0"
+        }
+        val initialItem = layoutInfo.currentItem ?: return initialVelocity
+        val targetIndex = layoutInfo.determineTargetIndex(
+            velocity = initialVelocity,
+            decayAnimationSpec = decayAnimationSpec,
+            maximumFlingDistance = maxFlingDistance,
+        ).let { target ->
+            snapIndex(
+                layoutInfo,
+                if (initialVelocity < 0) initialItem.index + 1 else initialItem.index,
+                target,
+            )
+        }.also {
+            require(it in 0..<layoutInfo.totalItemsCount)
+        }
+        return flingToIndex(index = targetIndex, initialVelocity = initialVelocity)
+    }
+
+    private suspend fun ScrollScope.flingToIndex(
+        index: Int,
+        initialVelocity: Float,
+    ): Float {
+        val initialItem = layoutInfo.currentItem ?: return initialVelocity
+        if (initialItem.index == index && layoutInfo.distanceToIndexSnap(initialItem.index) == 0) {
+            return consumeVelocityIfNotAtScrollEdge(initialVelocity)
+        }
+        var velocityLeft = initialVelocity
+        if (decayAnimationSpec.canDecayBeyondCurrentItem(initialVelocity, initialItem)) {
+            velocityLeft = performDecayFling(
+                initialItem = initialItem,
+                targetIndex = index,
+                initialVelocity = velocityLeft,
+            )
+        }
+        val currentItem = layoutInfo.currentItem ?: return initialVelocity
+        if (currentItem.index != index || layoutInfo.distanceToIndexSnap(index) != 0) {
+            velocityLeft = performSpringFling(
+                initialItem = currentItem,
+                targetIndex = index,
+                initialVelocity = velocityLeft,
+            )
+        }
+        return consumeVelocityIfNotAtScrollEdge(velocityLeft)
+    }
+
+    private suspend fun ScrollScope.performDecayFling(
+        initialItem: SnapperLayoutItemInfo,
+        targetIndex: Int,
+        initialVelocity: Float,
+        flingThenSpring: Boolean = true,
+    ): Float {
+        if (initialItem.index == targetIndex && layoutInfo.distanceToIndexSnap(initialItem.index) == 0) {
+            return consumeVelocityIfNotAtScrollEdge(initialVelocity)
+        }
+        var velocityLeft = initialVelocity
+        var lastValue = 0f
+        val canSpringThenFling = flingThenSpring && abs(targetIndex - initialItem.index) >= 2
+        try {
+            animationTarget = targetIndex
+            AnimationState(
+                initialValue = 0f,
+                initialVelocity = initialVelocity,
+            ).animateDecay(decayAnimationSpec) {
+                val delta = value - lastValue
+                val consumed = scrollBy(delta)
+                lastValue = value
+                velocityLeft = velocity
+                if (abs(delta - consumed) > 0.5f) {
+                    cancelAnimation()
+                }
+                val currentItem = layoutInfo.currentItem
+                if (currentItem == null) {
+                    cancelAnimation()
+                    return@animateDecay
+                }
+                if (isRunning && canSpringThenFling) {
+                    if (velocity > 0 && currentItem.index == targetIndex - 1) {
+                        cancelAnimation()
+                    } else if (velocity < 0 && currentItem.index == targetIndex) {
+                        cancelAnimation()
+                    }
+                }
+                if (isRunning && performSnapBackIfNeeded(currentItem, targetIndex, ::scrollBy)) {
+                    cancelAnimation()
+                }
+            }
+        } finally {
+            animationTarget = null
+        }
+        return velocityLeft
+    }
+
+    private suspend fun ScrollScope.performSpringFling(
+        initialItem: SnapperLayoutItemInfo,
+        targetIndex: Int,
+        initialVelocity: Float = 0f,
+    ): Float {
+        var velocityLeft = when {
+            targetIndex > initialItem.index && initialVelocity > 0 -> initialVelocity
+            targetIndex <= initialItem.index && initialVelocity < 0 -> initialVelocity
+            else -> 0f
+        }
+        var lastValue = 0f
+        try {
+            animationTarget = targetIndex
+            AnimationState(
+                initialValue = lastValue,
+                initialVelocity = velocityLeft,
+            ).animateTo(
+                targetValue = layoutInfo.distanceToIndexSnap(targetIndex).toFloat(),
+                animationSpec = springAnimationSpec,
+            ) {
+                val delta = value - lastValue
+                val consumed = scrollBy(delta)
+                lastValue = value
+                velocityLeft = velocity
+                val currentItem = layoutInfo.currentItem
+                if (currentItem == null) {
+                    cancelAnimation()
+                    return@animateTo
+                }
+                if (performSnapBackIfNeeded(currentItem, targetIndex, ::scrollBy)) {
+                    cancelAnimation()
+                } else if (abs(delta - consumed) > 0.5f) {
+                    cancelAnimation()
+                }
+            }
+        } finally {
+            animationTarget = null
+        }
+        return velocityLeft
+    }
+
+    private fun AnimationScope<Float, AnimationVector1D>.performSnapBackIfNeeded(
+        currentItem: SnapperLayoutItemInfo,
+        targetIndex: Int,
+        scrollBy: (pixels: Float) -> Float,
+    ): Boolean {
+        val snapBackAmount = calculateSnapBack(velocity, currentItem, targetIndex)
+        if (snapBackAmount != 0) {
+            scrollBy(snapBackAmount.toFloat())
+            return true
+        }
+        return false
+    }
+
+    private fun DecayAnimationSpec<Float>.canDecayBeyondCurrentItem(
+        velocity: Float,
+        currentItem: SnapperLayoutItemInfo,
+    ): Boolean {
+        if (velocity.absoluteValue < 0.5f) return false
+        val flingDistance = calculateTargetValue(0f, velocity)
+        return if (velocity < 0) {
+            flingDistance <= layoutInfo.distanceToIndexSnap(currentItem.index)
+        } else {
+            flingDistance >= layoutInfo.distanceToIndexSnap(currentItem.index + 1)
+        }
+    }
+
+    private fun calculateSnapBack(
+        initialVelocity: Float,
+        currentItem: SnapperLayoutItemInfo,
+        targetIndex: Int,
+    ): Int = when {
+        initialVelocity > 0 && currentItem.index >= targetIndex -> {
+            layoutInfo.distanceToIndexSnap(currentItem.index)
+        }
+
+        initialVelocity < 0 && currentItem.index <= targetIndex - 1 -> {
+            layoutInfo.distanceToIndexSnap(currentItem.index + 1)
+        }
+
+        else -> 0
+    }
+
+    private fun consumeVelocityIfNotAtScrollEdge(velocity: Float): Float {
+        if (velocity < 0 && !layoutInfo.canScrollTowardsStart()) {
+            return velocity
+        } else if (velocity > 0 && !layoutInfo.canScrollTowardsEnd()) {
+            return velocity
+        }
+        return 0f
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/DefaultWeekHeader.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/DefaultWeekHeader.kt
@@ -1,0 +1,47 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.week
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.datetime.DayOfWeek
+
+@Composable
+fun DefaultDaysOfWeekHeader(
+    daysOfWeek: List<DayOfWeek>,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier) {
+        daysOfWeek.forEach { dayOfWeek ->
+            Text(
+                textAlign = TextAlign.Center,
+                text = dayOfWeek.name.lowercase().take(3).replaceFirstChar { it.uppercaseChar() },
+                modifier = modifier
+                    .weight(1f)
+                    .wrapContentHeight(),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+internal fun <T> List<T>.rotateRight(n: Int): List<T> = takeLast(n) + dropLast(n)

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/Week.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/Week.kt
@@ -1,0 +1,64 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.week
+
+import `in`.procyk.compose.calendar.selection.fillUpTo
+import `in`.procyk.compose.calendar.util.daysUntil
+import `in`.procyk.compose.calendar.util.now
+import `in`.procyk.compose.calendar.year.YearMonth
+import kotlinx.datetime.*
+
+data class Week(
+    val days: List<LocalDate>,
+) {
+
+    init {
+        require(days.size == DaysInAWeek)
+    }
+
+    internal constructor(firstDay: LocalDate) : this(
+        listOf(firstDay).fillUpTo(firstDay.plus(DaysInAWeek - 1, DateTimeUnit.DAY))
+    )
+
+    val start: LocalDate get() = days.first()
+
+    val end: LocalDate get() = days.last()
+
+    val yearMonth: YearMonth = YearMonth.of(start.year, start.month)
+
+    operator fun inc(): Week = plusWeeks(1)
+
+    operator fun dec(): Week = plusWeeks(-1)
+
+    operator fun compareTo(other: Week): Int = start.compareTo(other.start)
+
+    fun minusWeeks(value: Long): Week = plusWeeks(-value)
+
+    fun plusWeeks(value: Long): Week = copy(days = days.map { it.plus(value, DateTimeUnit.WEEK) })
+
+    companion object {
+        fun now(firstDayOfWeek: DayOfWeek = DayOfWeek.MONDAY): Week {
+            val today = LocalDate.now()
+            val offset = today.dayOfWeek.daysUntil(firstDayOfWeek)
+            val firstDay = today.minus(offset, DateTimeUnit.DAY)
+
+            return Week(firstDay)
+        }
+    }
+}
+
+internal fun weeksBetween(first: Week, other: Week): Int =
+    (other.start - first.start).days / DaysInAWeek

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekDays.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekDays.kt
@@ -1,0 +1,25 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.week
+
+import androidx.compose.runtime.Immutable
+import `in`.procyk.compose.calendar.day.Day
+
+@Immutable
+internal data class WeekDays(
+    val isFirstWeekOfTheMonth: Boolean = false,
+    val days: List<Day>,
+)

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekListState.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekListState.kt
@@ -1,0 +1,80 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.week
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
+import `in`.procyk.compose.calendar.header.WeekState
+import `in`.procyk.compose.calendar.util.throttleOnOffset
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+@Stable
+internal class WeekListState(
+    private val coroutineScope: CoroutineScope,
+    private val weekState: WeekState,
+    private val listState: LazyListState,
+) {
+
+    private val currentlyFirstVisibleMonth by derivedStateOf {
+        getWeekForPage(listState.firstVisibleItemIndex)
+    }
+
+    init {
+        snapshotFlow { weekState.currentWeek }.onEach { week ->
+            moveToWeek(week)
+        }.launchIn(coroutineScope)
+
+        snapshotFlow { currentlyFirstVisibleMonth }
+            .throttleOnOffset(listState)
+            .onEach { newMonth ->
+                weekState.currentWeek = newMonth
+            }.launchIn(coroutineScope)
+    }
+
+    fun getWeekForPage(index: Int): Week =
+        weekState.minWeek.plusWeeks(index.toLong())
+
+    private fun moveToWeek(week: Week) {
+        if (week == currentlyFirstVisibleMonth) return
+        coroutineScope.launch {
+            listState.animateScrollToItem(weeksBetween(weekState.minWeek, week))
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as WeekListState
+
+        if (weekState != other.weekState) return false
+        if (listState != other.listState) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = weekState.hashCode()
+        result = 31 * result + listState.hashCode()
+        return result
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekPager.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekPager.kt
@@ -1,0 +1,156 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.week
+
+import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import `in`.procyk.compose.calendar.day.DayState
+import `in`.procyk.compose.calendar.day.WeekDay
+import `in`.procyk.compose.calendar.header.WeekState
+import `in`.procyk.compose.calendar.month.coerceSnapIndex
+import `in`.procyk.compose.calendar.selection.SelectionState
+import `in`.procyk.compose.calendar.util.SnapOffsets
+import `in`.procyk.compose.calendar.util.SnapperFlingBehaviorDefaults
+import `in`.procyk.compose.calendar.util.rememberSnapperFlingBehavior
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+
+@Composable
+@Suppress("LongMethod")
+internal fun <T : SelectionState> WeekPager(
+    initialWeek: Week,
+    selectionState: T,
+    weekState: WeekState,
+    daysOfWeek: List<DayOfWeek>,
+    today: LocalDate,
+    modifier: Modifier = Modifier,
+    weekDaysScrollEnabled: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState<T>) -> Unit,
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    val initialFirstVisibleItemIndex = remember(initialWeek, weekState.minWeek) {
+        weeksBetween(weekState.minWeek, initialWeek)
+    }
+    val listState = rememberLazyListState(
+        initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
+    )
+    val flingBehavior = rememberSnapperFlingBehavior(
+        lazyListState = listState,
+        snapOffsetForItem = SnapOffsets.Start,
+        springAnimationSpec = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+        decayAnimationSpec = rememberSplineBasedDecay(),
+        snapIndex = coerceSnapIndex,
+    )
+
+    val weekListState = remember {
+        WeekListState(
+            coroutineScope = coroutineScope,
+            weekState = weekState,
+            listState = listState,
+        )
+    }
+    Column(
+        modifier = modifier,
+    ) {
+        if (weekDaysScrollEnabled.not()) {
+            Box(
+                modifier = Modifier
+                    .wrapContentHeight()
+                    .fillMaxWidth(),
+                content = { daysOfWeekHeader(daysOfWeek) },
+            )
+        }
+        val pagerCount = remember(weekState.minWeek, weekState.maxWeek) {
+            weeksBetween(weekState.minWeek, weekState.maxWeek) + 1
+        }
+        LazyRow(
+            modifier = modifier.testTag("WeekPager"),
+            state = listState,
+            flingBehavior = flingBehavior,
+            verticalAlignment = Alignment.Top,
+        ) {
+            items(
+                count = pagerCount,
+                key = { index -> weekListState.getWeekForPage(index).start.let { "${it.month}-${it.dayOfMonth}" } },
+            ) { index ->
+                WeekContent(
+                    modifier = Modifier.fillParentMaxWidth(),
+                    daysOfWeek = daysOfWeek,
+                    weekDays = weekListState.getWeekForPage(index).getWeekDays(today = today),
+                    selectionState = selectionState,
+                    weekDaysScrollEnabled = weekDaysScrollEnabled,
+                    dayContent = dayContent,
+                    daysOfWeekHeader = daysOfWeekHeader,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun <T : SelectionState> WeekContent(
+    selectionState: T,
+    weekDays: WeekDays,
+    daysOfWeek: List<DayOfWeek>,
+    modifier: Modifier = Modifier,
+    weekDaysScrollEnabled: Boolean = true,
+    dayContent: @Composable BoxScope.(DayState<T>) -> Unit,
+    daysOfWeekHeader: @Composable BoxScope.(List<DayOfWeek>) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+    ) {
+        if (weekDaysScrollEnabled) {
+            Box(
+                modifier = Modifier
+                    .wrapContentHeight()
+                    .fillMaxWidth(),
+                content = { daysOfWeekHeader(daysOfWeek) },
+            )
+        }
+        WeekRow(
+            weekDays = weekDays,
+            modifier = Modifier.fillMaxWidth(),
+            selectionState = selectionState,
+            dayContent = dayContent,
+        )
+    }
+}
+
+internal fun Week.getWeekDays(today: LocalDate): WeekDays {
+    val weekDays = days.map {
+        WeekDay(
+            date = it,
+            isCurrentDay = it == today,
+            isFromCurrentMonth = true,
+        )
+    }
+
+    return WeekDays(
+        isFirstWeekOfTheMonth = false,
+        days = weekDays,
+    )
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekRow.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekRow.kt
@@ -1,0 +1,45 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.week
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import `in`.procyk.compose.calendar.day.DayState
+import `in`.procyk.compose.calendar.selection.SelectionState
+
+@Composable
+internal fun <T : SelectionState> WeekRow(
+    weekDays: WeekDays,
+    selectionState: T,
+    modifier: Modifier = Modifier,
+    dayContent: @Composable BoxScope.(DayState<T>) -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        horizontalArrangement = if (weekDays.isFirstWeekOfTheMonth) Arrangement.End else Arrangement.Start
+    ) {
+        weekDays.days.forEachIndexed { index, day ->
+            Box(
+                modifier = Modifier.fillMaxWidth(1f / (7 - index))
+            ) {
+                dayContent(DayState(day, selectionState))
+            }
+        }
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekUtil.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/week/WeekUtil.kt
@@ -1,0 +1,66 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.week
+
+import `in`.procyk.compose.calendar.day.WeekDay
+import `in`.procyk.compose.calendar.util.daysUntil
+import `in`.procyk.compose.calendar.util.now
+import `in`.procyk.compose.calendar.year.YearMonth
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+
+internal const val DaysInAWeek = 7
+
+internal fun YearMonth.getWeeks(
+    includeAdjacentMonths: Boolean,
+    firstDayOfTheWeek: DayOfWeek,
+    today: LocalDate = LocalDate.now(),
+): List<WeekDays> {
+    val daysLength = lengthOfMonth()
+
+    val starOffset = atDay(1).dayOfWeek daysUntil firstDayOfTheWeek
+    val endOffset = DaysInAWeek - (atDay(daysLength).dayOfWeek daysUntil firstDayOfTheWeek) - 1
+
+    return (1 - starOffset..daysLength + endOffset).chunked(DaysInAWeek).mapIndexed { index, days ->
+        WeekDays(
+            isFirstWeekOfTheMonth = index == 0,
+            days = days.mapNotNull { dayOfMonth ->
+                val (date, isFromCurrentMonth) = when (dayOfMonth) {
+                    in Int.MIN_VALUE..0 -> if (includeAdjacentMonths) {
+                        val previousMonth = this.minusMonths(1)
+                        previousMonth.atDay(previousMonth.lengthOfMonth() + dayOfMonth) to false
+                    } else {
+                        return@mapNotNull null
+                    }
+
+                    in 1..daysLength -> atDay(dayOfMonth) to true
+                    else -> if (includeAdjacentMonths) {
+                        val previousMonth = this.plusMonths(1)
+                        previousMonth.atDay(dayOfMonth - daysLength) to false
+                    } else {
+                        return@mapNotNull null
+                    }
+                }
+
+                WeekDay(
+                    date = date,
+                    isFromCurrentMonth = isFromCurrentMonth,
+                    isCurrentDay = date.equals(today),
+                )
+            }
+        )
+    }
+}

--- a/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/year/YearMonth.kt
+++ b/calendar/src/commonMain/kotlin/in/procyk/compose/calendar/year/YearMonth.kt
@@ -1,0 +1,121 @@
+/**
+ * Based on ComposeCalendar by Bogusz Pawłowski from [Github](https://github.com/boguszpawlowski/ComposeCalendar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package `in`.procyk.compose.calendar.year
+
+import androidx.compose.runtime.Immutable
+import `in`.procyk.compose.calendar.util.now
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
+import kotlinx.datetime.number
+
+
+@Immutable
+class YearMonth private constructor(
+    val year: Int,
+    val month: Int,
+) : Comparable<YearMonth> {
+
+    operator fun dec(): YearMonth = minusMonths(1)
+
+    operator fun inc(): YearMonth = plusMonths(1)
+
+    override fun toString(): String = "$year-$month"
+
+    override fun compareTo(other: YearMonth): Int =
+        year.compareTo(other.year)
+            .let { if (it == 0) month.compareTo(other.month) else it }
+
+    fun plusMonths(count: Long): YearMonth {
+        if (count == 0L) {
+            return this
+        }
+        val monthCount = year * 12L + (month - 1)
+        val calcMonths = monthCount + count
+        val newYear = calcMonths.floorDiv(12)
+        val newMonth = floorMod(calcMonths, 12) + 1
+        return YearMonth(newYear.toInt(), newMonth.toInt())
+    }
+
+    fun minusMonths(count: Long): YearMonth =
+        if (count == Long.MIN_VALUE) plusMonths(Long.MAX_VALUE).plusMonths(1) else plusMonths(-count)
+
+    fun atDay(dayOfMonth: Int): LocalDate {
+        return LocalDate(year, Month(month), dayOfMonth)
+    }
+
+    fun lengthOfMonth(): Int =
+        month.monthLength(isLeapYear(year))
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as YearMonth
+
+        if (year != other.year) return false
+        if (month != other.month) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = year
+        result = 31 * result + month
+        return result
+    }
+
+
+    companion object {
+        fun now(): YearMonth =
+            LocalDate.now().let { of(it.year, it.month) }
+
+        fun of(year: Int, month: Month): YearMonth =
+            YearMonth(year, month.number)
+
+        fun parse(value: String): YearMonth? = runCatching {
+            val (yearString, monthString) = value.split('-')
+            val year = yearString.toInt()
+            val month = monthString.toInt()
+            YearMonth(year, month)
+        }.getOrNull()
+
+        fun monthsBetween(start: YearMonth, end: YearMonth): Long {
+            return end.encoded - start.encoded
+        }
+    }
+}
+
+private inline val YearMonth.encoded: Long get() = year * 12L + (month - 1)
+
+private fun floorMod(x: Long, y: Long): Long {
+    var r = x / y
+    if ((x xor y) < 0 && (r * y != x)) {
+        r--
+    }
+    return x - r * y
+}
+
+private fun isLeapYear(year: Int): Boolean {
+    val prolepticYear = year.toLong()
+    return prolepticYear and 3 == 0L && (prolepticYear % 100 != 0L || prolepticYear % 400 == 0L)
+}
+
+private fun Int.monthLength(isLeapYear: Boolean): Int =
+    when (this) {
+        2 -> if (isLeapYear) 29 else 28
+        4, 6, 9, 11 -> 30
+        else -> 31
+    }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-accompanist = "0.32.0"
+accompanist = "0.34.0"
 # @keep
 android-compileSdk = "33"
 # @pin
@@ -9,8 +9,8 @@ android-minSdk = "26"
 # @keep
 android-targetSdk = "33"
 barcodeScanning = "17.2.0"
-cameraX = "1.3.0"
-compose = "1.6.0-rc02"
+cameraX = "1.3.2"
+compose = "1.6.0"
 # @keep
 compose-extensions = "1.6.0-rc02.1"
 gradle-versions = "0.51.0"
@@ -20,7 +20,7 @@ kotlinxDatetime = "0.6.0-RC.2"
 version-catalog-update = "0.8.4"
 webcamCapture = "0.3.12"
 webcamCaptureDriverNative = "1.0.0"
-zxing-core = "3.5.2"
+zxing-core = "3.5.3"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,12 +10,13 @@ android-minSdk = "26"
 android-targetSdk = "33"
 barcodeScanning = "17.2.0"
 cameraX = "1.3.0"
-compose = "1.6.0"
+compose = "1.6.0-rc02"
 # @keep
-compose-extensions = "1.6.0.0"
+compose-extensions = "1.6.0-rc02.1"
 gradle-versions = "0.51.0"
 # @pin
-kotlin = "2.0.0-Beta4"
+kotlin = "1.9.22"
+kotlinxDatetime = "0.6.0-RC.2"
 version-catalog-update = "0.8.4"
 webcamCapture = "0.3.12"
 webcamCaptureDriverNative = "1.0.0"
@@ -27,6 +28,7 @@ accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-
 androidx-camera = { module = "androidx.camera:camera-camera2", version.ref = "cameraX" }
 androidx-cameraLifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraX" }
 androidx-cameraPreview = { module = "androidx.camera:camera-view", version.ref = "cameraX" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 mlkit-barcodeScanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "barcodeScanning" }
 webcam-capture = { module = "com.github.sarxos:webcam-capture", version.ref = "webcamCapture" }
 webcam-capture-driver-native = { module = "io.github.eduramiba:webcam-capture-driver-native", version.ref = "webcamCaptureDriverNative" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "compose-extensions"
 
 includeBuild("convention-plugins")
+include("calendar")
 include("camera-permission")
 include("camera-qr")
 include("util")


### PR DESCRIPTION
The following dependencies are using the latest milestone version:
 - androidx.activity:activity:1.7.2
 - androidx.activity:activity-compose:1.7.2
 - androidx.activity:activity-ktx:1.7.2
 - androidx.annotation:annotation:1.7.0
 - androidx.annotation:annotation-experimental:1.3.1
 - androidx.annotation:annotation-jvm:1.7.0
 - androidx.appcompat:appcompat:1.1.0
 - androidx.appcompat:appcompat-resources:1.1.0
 - androidx.arch.core:core-common:2.2.0
 - androidx.arch.core:core-runtime:2.2.0
 - androidx.autofill:autofill:1.0.0
 - androidx.camera:camera-core:1.3.0
 - androidx.camera:camera-video:1.3.0
 - androidx.collection:collection:1.4.0
 - androidx.collection:collection-jvm:1.4.0
 - androidx.collection:collection-ktx:1.4.0
 - androidx.compose.animation:animation:1.6.1
 - androidx.compose.animation:animation-android:1.6.1
 - androidx.compose.animation:animation-core:1.6.1
 - androidx.compose.animation:animation-core-android:1.6.1
 - androidx.compose.foundation:foundation:1.6.1
 - androidx.compose.foundation:foundation-android:1.6.1
 - androidx.compose.foundation:foundation-layout:1.6.1
 - androidx.compose.foundation:foundation-layout-android:1.6.1
 - androidx.compose.runtime:runtime:1.6.1
 - androidx.compose.runtime:runtime-android:1.6.1
 - androidx.compose.runtime:runtime-saveable:1.6.1
 - androidx.compose.runtime:runtime-saveable-android:1.6.1
 - androidx.compose.ui:ui:1.6.1
 - androidx.compose.ui:ui-android:1.6.1
 - androidx.compose.ui:ui-geometry:1.6.1
 - androidx.compose.ui:ui-geometry-android:1.6.1
 - androidx.compose.ui:ui-graphics:1.6.1
 - androidx.compose.ui:ui-graphics-android:1.6.1
 - androidx.compose.ui:ui-text:1.6.1
 - androidx.compose.ui:ui-text-android:1.6.1
 - androidx.compose.ui:ui-unit:1.6.1
 - androidx.compose.ui:ui-unit-android:1.6.1
 - androidx.compose.ui:ui-util:1.6.1
 - androidx.compose.ui:ui-util-android:1.6.1
 - androidx.concurrent:concurrent-futures:1.1.0
 - androidx.core:core:1.12.0
 - androidx.core:core-ktx:1.12.0
 - androidx.cursoradapter:cursoradapter:1.0.0
 - androidx.customview:customview:1.0.0
 - androidx.customview:customview-poolingcontainer:1.0.0
 - androidx.drawerlayout:drawerlayout:1.0.0
 - androidx.emoji2:emoji2:1.3.0
 - androidx.exifinterface:exifinterface:1.3.2
 - androidx.fragment:fragment:1.1.0
 - androidx.interpolator:interpolator:1.0.0
 - androidx.lifecycle:lifecycle-common:2.6.1
 - androidx.lifecycle:lifecycle-livedata:2.6.1
 - androidx.lifecycle:lifecycle-livedata-core:2.6.1
 - androidx.lifecycle:lifecycle-process:2.6.1
 - androidx.lifecycle:lifecycle-runtime:2.6.1
 - androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
 - androidx.loader:loader:1.0.0
 - androidx.profileinstaller:profileinstaller:1.3.0
 - androidx.savedstate:savedstate:1.2.1
 - androidx.savedstate:savedstate-ktx:1.2.1
 - androidx.startup:startup-runtime:1.1.1
 - androidx.tracing:tracing:1.0.0
 - androidx.vectordrawable:vectordrawable:1.1.0
 - androidx.vectordrawable:vectordrawable-animated:1.1.0
 - androidx.versionedparcelable:versionedparcelable:1.1.1
 - androidx.viewpager:viewpager:1.0.0
 - com.android.library:com.android.library.gradle.plugin:8.2.2
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.51.0
 - com.github.sarxos:webcam-capture:0.3.12
 - com.google.android.datatransport:transport-api:2.2.1
 - com.google.android.datatransport:transport-backend-cct:2.3.3
 - com.google.android.datatransport:transport-runtime:2.2.6
 - com.google.android.gms:play-services-base:18.1.0
 - com.google.android.gms:play-services-basement:18.1.0
 - com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.0
 - com.google.android.gms:play-services-tasks:18.0.2
 - com.google.auto.value:auto-value-annotations:1.6.3
 - com.google.firebase:firebase-annotations:16.0.0
 - com.google.firebase:firebase-components:16.1.0
 - com.google.firebase:firebase-encoders:16.1.0
 - com.google.firebase:firebase-encoders-json:17.1.0
 - com.google.guava:listenablefuture:1.0
 - com.google.mlkit:barcode-scanning:17.2.0
 - com.google.mlkit:barcode-scanning-common:17.0.0
 - com.google.mlkit:common:18.9.0
 - com.google.mlkit:vision-common:17.3.0
 - com.google.mlkit:vision-interfaces:16.2.0
 - io.github.aakira:napier:1.4.1
 - io.github.aakira:napier-android:1.4.1
 - io.github.aakira:napier-android-debug:1.4.1
 - io.github.eduramiba:webcam-capture-driver-native:1.0.0
 - javax.inject:javax.inject:1
 - nl.littlerobots.version-catalog-update:nl.littlerobots.version-catalog-update.gradle.plugin:0.8.4
 - org.jetbrains:annotations:23.0.0
 - org.jetbrains.kotlin:kotlin-build-tools-impl:2.0.0-Beta4
 - org.jetbrains.kotlin:kotlin-compiler-embeddable:2.0.0-Beta4
 - org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:2.0.0-Beta4
 - org.jetbrains.kotlin:kotlin-native-prebuilt:2.0.0-Beta4
 - org.jetbrains.kotlin:kotlin-reflect:1.8.20
 - org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0
 - org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1
 - org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.1
 - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1
 - org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1

The following dependencies exceed the version found at the milestone revision level:
 - org.jetbrains.compose:org.jetbrains.compose.gradle.plugin [1.6.0-rc03 <- 1.5.12]
     https://github.com/JetBrains/compose-jb
 - org.jetbrains.compose.compiler:compiler [1.5.9-kt-2.0.0-Beta4 <- 1.5.8.1]
     https://github.com/JetBrains/compose-jb
 - org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable [2.0.0-Beta4 <- 1.9.22]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-test-js-runner [2.0.0-Beta4 <- 1.9.22]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin [2.0.0-Beta4 <- 1.9.22]
     https://kotlinlang.org/

The following dependencies have later milestone versions:
 - androidx.activity:activity [1.7.0 -> 1.7.2]
     https://developer.android.com/jetpack/androidx/releases/activity#1.7.0
 - androidx.activity:activity-ktx [1.7.0 -> 1.7.2]
     https://developer.android.com/jetpack/androidx/releases/activity#1.7.2
 - androidx.annotation:annotation-experimental [1.3.0 -> 1.3.1]
     https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0
 - androidx.camera:camera-camera2 [1.3.0 -> 1.3.1]
     https://developer.android.com/jetpack/androidx/releases/camera#1.3.1
 - androidx.camera:camera-lifecycle [1.3.0 -> 1.3.1]
     https://developer.android.com/jetpack/androidx/releases/camera#1.3.1
 - androidx.camera:camera-view [1.3.0 -> 1.3.1]
     https://developer.android.com/jetpack/androidx/releases/camera#1.3.1
 - com.google.accompanist:accompanist-permissions [0.32.0 -> 0.34.0]
     https://github.com/google/accompanist/
 - com.google.accompanist:accompanist-systemuicontroller [0.32.0 -> 0.34.0]
     https://github.com/google/accompanist/
 - com.google.zxing:javase [3.5.2 -> 3.5.3]
     https://github.com/zxing/zxing
 - org.apache.logging.log4j:log4j-core [2.17.1 -> 2.23.0]
     https://logging.apache.org/log4j/2.x/
 - org.jetbrains:annotations [13.0 -> 23.0.0]
     http://www.jetbrains.org
 - org.jetbrains.kotlin:kotlin-stdlib [1.8.20 -> 2.0.0-Beta4]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7 [1.8.20 -> 1.9.0]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8 [1.8.20 -> 1.9.0]
     https://kotlinlang.org/

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.google.android.odml:image
     1.0.0-beta1
 - org.jetbrains.compose.foundation:foundation
     1.5.12
 - org.jetbrains.compose.runtime:runtime
     1.5.12
 - org.jetbrains.compose.ui:ui
     1.5.12
 - org.jetbrains.kotlin:kotlin-stdlib
     2.0.0-Beta4

Gradle release-candidate updates:
 - Gradle: [8.2.1 -> 8.6 -> 8.7-rc-1]