### PR TITLE
Update Dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-accompanist = "0.32.0"
+accompanist = "0.37.3"
 # @keep
 android-compileSdk = "33"
 # @pin
@@ -9,22 +9,22 @@ android-minSdk = "26"
 # @keep
 android-targetSdk = "33"
 barcodeScanning = "17.3.0"
-cameraX = "1.3.4"
-compose = "1.6.11"
+cameraX = "1.4.2"
+compose = "1.9.0-SNAPSHOT+release-1-8-data-source-prototype"
 # @keep
 compose-extensions = "1.6.11.0"
-gradle-versions = "0.51.0"
+gradle-versions = "0.52.0"
 # @pin
 kotlin = "2.0.20"
 kotlinxDatetime = "0.6.0"
-version-catalog-update = "0.8.4"
+version-catalog-update = "1.0.0"
 webcamCapture = "0.3.12"
-webcamCaptureDriverNative = "1.0.0"
+webcamCaptureDriverNative = "1.2.0"
 zxing-core = "3.5.3"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
-accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
+accompanist-systemuicontroller = "com.google.accompanist:accompanist-systemuicontroller:0.36.0"
 androidx-camera = { module = "androidx.camera:camera-camera2", version.ref = "cameraX" }
 androidx-cameraLifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraX" }
 androidx-cameraPreview = { module = "androidx.camera:camera-view", version.ref = "cameraX" }
@@ -36,8 +36,8 @@ zxing-javase = { module = "com.google.zxing:javase", version.ref = "zxing-core" 
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
-compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 gradle-versions = { id = "com.github.ben-manes.versions", version.ref = "gradle-versions" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "version-catalog-update" }


### PR DESCRIPTION
The following dependencies are using the latest milestone version:
 - androidx.activity:activity:1.7.2
 - androidx.activity:activity-compose:1.7.2
 - androidx.activity:activity-ktx:1.7.2
 - androidx.annotation:annotation:1.7.0
 - androidx.annotation:annotation-experimental:1.4.0
 - androidx.annotation:annotation-jvm:1.7.0
 - androidx.appcompat:appcompat:1.6.1
 - androidx.appcompat:appcompat-resources:1.6.1
 - androidx.arch.core:core-common:2.2.0
 - androidx.arch.core:core-runtime:2.2.0
 - androidx.autofill:autofill:1.0.0
 - androidx.camera:camera-core:1.3.4
 - androidx.camera:camera-video:1.3.4
 - androidx.collection:collection:1.4.0
 - androidx.collection:collection-jvm:1.4.0
 - androidx.collection:collection-ktx:1.4.0
 - androidx.compose.animation:animation:1.6.7
 - androidx.compose.animation:animation-android:1.6.7
 - androidx.compose.animation:animation-core:1.6.7
 - androidx.compose.animation:animation-core-android:1.6.7
 - androidx.compose.foundation:foundation:1.6.7
 - androidx.compose.foundation:foundation-android:1.6.7
 - androidx.compose.foundation:foundation-layout:1.6.7
 - androidx.compose.foundation:foundation-layout-android:1.6.7
 - androidx.compose.material:material-icons-core:1.6.0
 - androidx.compose.material:material-icons-core-android:1.6.0
 - androidx.compose.material:material-ripple:1.6.0
 - androidx.compose.material:material-ripple-android:1.6.0
 - androidx.compose.material3:material3:1.2.1
 - androidx.compose.material3:material3-android:1.2.1
 - androidx.compose.runtime:runtime:1.6.7
 - androidx.compose.runtime:runtime-android:1.6.7
 - androidx.compose.runtime:runtime-saveable:1.6.7
 - androidx.compose.runtime:runtime-saveable-android:1.6.7
 - androidx.compose.ui:ui:1.6.7
 - androidx.compose.ui:ui-android:1.6.7
 - androidx.compose.ui:ui-geometry:1.6.7
 - androidx.compose.ui:ui-geometry-android:1.6.7
 - androidx.compose.ui:ui-graphics:1.6.7
 - androidx.compose.ui:ui-graphics-android:1.6.7
 - androidx.compose.ui:ui-text:1.6.7
 - androidx.compose.ui:ui-text-android:1.6.7
 - androidx.compose.ui:ui-unit:1.6.7
 - androidx.compose.ui:ui-unit-android:1.6.7
 - androidx.compose.ui:ui-util:1.6.7
 - androidx.compose.ui:ui-util-android:1.6.7
 - androidx.concurrent:concurrent-futures:1.1.0
 - androidx.core:core:1.12.0
 - androidx.core:core-ktx:1.12.0
 - androidx.cursoradapter:cursoradapter:1.0.0
 - androidx.customview:customview:1.0.0
 - androidx.customview:customview-poolingcontainer:1.0.0
 - androidx.drawerlayout:drawerlayout:1.0.0
 - androidx.emoji2:emoji2:1.3.0
 - androidx.emoji2:emoji2-views-helper:1.3.0
 - androidx.exifinterface:exifinterface:1.3.2
 - androidx.fragment:fragment:1.3.6
 - androidx.interpolator:interpolator:1.0.0
 - androidx.lifecycle:lifecycle-common:2.6.1
 - androidx.lifecycle:lifecycle-common-java8:2.6.1
 - androidx.lifecycle:lifecycle-livedata:2.6.1
 - androidx.lifecycle:lifecycle-livedata-core:2.6.1
 - androidx.lifecycle:lifecycle-process:2.6.1
 - androidx.lifecycle:lifecycle-runtime:2.6.1
 - androidx.lifecycle:lifecycle-runtime-ktx:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1
 - androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1
 - androidx.loader:loader:1.0.0
 - androidx.profileinstaller:profileinstaller:1.3.0
 - androidx.resourceinspection:resourceinspection-annotation:1.0.1
 - androidx.savedstate:savedstate:1.2.1
 - androidx.savedstate:savedstate-ktx:1.2.1
 - androidx.startup:startup-runtime:1.1.1
 - androidx.tracing:tracing:1.0.0
 - androidx.vectordrawable:vectordrawable:1.1.0
 - androidx.vectordrawable:vectordrawable-animated:1.1.0
 - androidx.versionedparcelable:versionedparcelable:1.1.1
 - androidx.viewpager:viewpager:1.0.0
 - com.github.sarxos:webcam-capture:0.3.12
 - com.google.android.datatransport:transport-api:2.2.1
 - com.google.android.datatransport:transport-backend-cct:2.3.3
 - com.google.android.datatransport:transport-runtime:2.2.6
 - com.google.android.gms:play-services-base:18.5.0
 - com.google.android.gms:play-services-basement:18.4.0
 - com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1
 - com.google.android.gms:play-services-tasks:18.2.0
 - com.google.auto.value:auto-value-annotations:1.6.3
 - com.google.firebase:firebase-annotations:16.0.0
 - com.google.firebase:firebase-components:16.1.0
 - com.google.firebase:firebase-encoders:16.1.0
 - com.google.firebase:firebase-encoders-json:17.1.0
 - com.google.guava:listenablefuture:1.0
 - com.google.mlkit:barcode-scanning:17.3.0
 - com.google.mlkit:barcode-scanning-common:17.0.0
 - com.google.mlkit:common:18.11.0
 - com.google.mlkit:vision-common:17.3.0
 - com.google.mlkit:vision-interfaces:16.3.0
 - com.google.zxing:javase:3.5.3
 - io.github.aakira:napier:1.4.1
 - io.github.aakira:napier-android:1.4.1
 - io.github.aakira:napier-android-debug:1.4.1
 - javax.inject:javax.inject:1
 - org.jetbrains:annotations:23.0.0
 - org.jetbrains.kotlin:kotlin-build-tools-impl:2.0.20
 - org.jetbrains.kotlin:kotlin-compiler-embeddable:2.0.20
 - org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:2.0.20
 - org.jetbrains.kotlin:kotlin-native-prebuilt:2.0.20
 - org.jetbrains.kotlin:kotlin-reflect:1.8.20
 - org.jetbrains.kotlin:kotlin-stdlib-common:1.8.20
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.0
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0
 - org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1
 - org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.1
 - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1
 - org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1
 - org.jetbrains.kotlinx:kotlinx-datetime-jvm:0.6.0

The following dependencies have later milestone versions:
 - androidx.activity:activity [1.7.0 -> 1.7.2]
     https://developer.android.com/jetpack/androidx/releases/activity#1.7.0
 - androidx.activity:activity-compose [1.7.0 -> 1.7.2]
     https://developer.android.com/jetpack/androidx/releases/activity#1.7.2
 - androidx.activity:activity-ktx [1.7.0 -> 1.7.2]
     https://developer.android.com/jetpack/androidx/releases/activity#1.7.0
 - androidx.annotation:annotation-experimental [1.3.0 -> 1.4.0]
     https://developer.android.com/jetpack/androidx/releases/annotation#1.3.0
 - androidx.camera:camera-camera2 [1.3.4 -> 1.4.2]
     https://developer.android.com/jetpack/androidx/releases/camera#1.3.4
 - androidx.camera:camera-lifecycle [1.3.4 -> 1.4.2]
     https://developer.android.com/jetpack/androidx/releases/camera#1.3.4
 - androidx.camera:camera-view [1.3.4 -> 1.4.2]
     https://developer.android.com/jetpack/androidx/releases/camera#1.4.2
 - com.android.library:com.android.library.gradle.plugin [8.2.2 -> 8.12.0]
     https://developer.android.com/studio/build
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.51.0 -> 0.52.0]
 - com.google.accompanist:accompanist-permissions [0.32.0 -> 0.37.3]
     https://github.com/google/accompanist/
 - com.google.accompanist:accompanist-systemuicontroller [0.32.0 -> 0.36.0]
     https://github.com/google/accompanist/
 - io.github.eduramiba:webcam-capture-driver-native [1.0.0 -> 1.2.0]
     https://github.com/eduramiba/webcam-capture-driver-native
 - nl.littlerobots.version-catalog-update:nl.littlerobots.version-catalog-update.gradle.plugin [0.8.4 -> 1.0.0]
     https://github.com/littlerobots/version-catalog-update-plugin
 - org.apache.logging.log4j:log4j-core [2.17.1 -> 2.25.1]
     https://logging.apache.org/log4j/2.x/
 - org.jetbrains:annotations [13.0 -> 23.0.0]
     http://www.jetbrains.org
 - org.jetbrains.compose:org.jetbrains.compose.gradle.plugin [1.6.11 -> 1.9.0-SNAPSHOT+release-1-8-data-source-prototype]
 - org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable [2.0.20 -> 2.2.0]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable [2.0.20 -> 2.2.0]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib [1.8.20 -> 2.2.0]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7 [1.8.20 -> 1.9.0]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8 [1.8.20 -> 1.9.0]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin [2.0.20 -> 2.2.0]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin [2.0.20 -> 2.2.0]
     https://kotlinlang.org/
 - org.jetbrains.skiko:skiko-js-wasm-runtime [0.8.4 -> 0.9.22]
     https://www.github.com/JetBrains/skiko

Failed to compare versions for the following dependencies because they were declared without version:
 - org.jetbrains.kotlin:kotlin-test-js-runner

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.google.android.odml:image
     1.0.0-beta1
 - org.jetbrains.compose.foundation:foundation
     1.9.0-SNAPSHOT+release-1-8-data-source-prototype
 - org.jetbrains.compose.material3:material3
     1.9.0-SNAPSHOT+release-1-8-data-source-prototype
 - org.jetbrains.compose.runtime:runtime
     1.9.0-SNAPSHOT+release-1-8-data-source-prototype
 - org.jetbrains.compose.ui:ui
     1.9.0-SNAPSHOT+release-1-8-data-source-prototype
 - org.jetbrains.kotlin:kotlin-stdlib
     2.2.0
 - org.jetbrains.kotlinx:kotlinx-datetime
     0.7.1

Gradle release-candidate updates:
 - Gradle: [8.2.1 -> 9.0.0]